### PR TITLE
Incident Metadata

### DIFF
--- a/src/Builders/IncidentQuery.php
+++ b/src/Builders/IncidentQuery.php
@@ -28,6 +28,12 @@ class IncidentQuery extends BaseQuery
             });
 
             if($incident !== null) {
+                $incident = (array)$incident;
+
+                if(isset($incident['metadata'])) {
+                    unset($incident['metadata']);
+                }
+
                 return new Incident(
                     $this->getServer(),
                     (array)$incident


### PR DESCRIPTION
We found a bug when retrieving incident information, you would receive the following error message:

```
Fatal error: Uncaught TypeError: Argument 1 passed to CheckItOnUs\StatusPage\BaseApiComponent::setMetadata() must be of the type array, object given, called in /Users/judda/Documents/code/checkitonus/php-statuspage-sdk/src/Traits/HasMetadata.php on line 51 and defined in /Users/judda/Documents/code/checkitonus/php-statuspage-sdk/src/Traits/HasMetadata.php:94
Stack trace:
#0 /Users/judda/Documents/code/checkitonus/php-statuspage-sdk/src/Traits/HasMetadata.php(51): CheckItOnUs\StatusPage\BaseApiComponent->setMetadata(Object(stdClass))
#1 /Users/judda/Documents/code/checkitonus/php-statuspage-sdk/src/Traits/HasMetadata.php(101): CheckItOnUs\StatusPage\BaseApiComponent->offsetSet('metadata', Object(stdClass))
#2 /Users/judda/Documents/code/checkitonus/php-statuspage-sdk/src/BaseApiComponent.php(36): CheckItOnUs\StatusPage\BaseApiComponent->setMetadata(Array)
#3 /Users/judda/Documents/code/checkitonus/php-statuspage-sdk/src/Incident.php(43): CheckItOnUs\StatusPage\BaseApiComponent->__construct(Object(CheckItOnUs\StatusPage\Ser in /Users/judda/Documents/code/checkitonus/php-statuspage-sdk/src/Traits/HasMetadata.php on line 94
```

The payload from StatusPage includes the "metadata" keyword with an object which we do not use/consume and it causes this issue because of the direct setting of the value.